### PR TITLE
Fix chart dataset parsing

### DIFF
--- a/index.html
+++ b/index.html
@@ -138,8 +138,22 @@ function buildData(people, married) {
 }
 
 var taxChart;
-var lineDataset = { label: '稅額', data: [], borderColor: 'blue', pointRadius: 0, fill: false };
-var highlightDataset = { label: '輸入值', data: [], backgroundColor: 'red', pointRadius: 5, showLine: false };
+var lineDataset = {
+    label: '稅額',
+    data: [],
+    borderColor: 'blue',
+    pointRadius: 0,
+    fill: false,
+    parsing: { xAxisKey: 'x', yAxisKey: 'y' }
+};
+var highlightDataset = {
+    label: '輸入值',
+    data: [],
+    backgroundColor: 'red',
+    pointRadius: 5,
+    showLine: false,
+    parsing: { xAxisKey: 'x', yAxisKey: 'y' }
+};
 
 const hoverLine = {
     id: 'hoverLine',


### PR DESCRIPTION
## Summary
- set `parsing` options for line datasets so Chart.js recognizes the x/y values

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684ee64442e0832fab0a8cb3161e0aee